### PR TITLE
obs-frontend-api: Fix deadlock when setting current scene

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -99,14 +99,14 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_set_current_scene(obs_source_t *scene) override
 	{
 		if (main->IsPreviewProgramMode()) {
-			QMetaObject::invokeMethod(
-				main, "TransitionToScene", WaitConnection(),
-				Q_ARG(OBSSource, OBSSource(scene)));
+			QMetaObject::invokeMethod(main, "TransitionToScene",
+						  Q_ARG(OBSSource,
+							OBSSource(scene)));
 		} else {
-			QMetaObject::invokeMethod(
-				main, "SetCurrentScene", WaitConnection(),
-				Q_ARG(OBSSource, OBSSource(scene)),
-				Q_ARG(bool, false));
+			QMetaObject::invokeMethod(main, "SetCurrentScene",
+						  Q_ARG(OBSSource,
+							OBSSource(scene)),
+						  Q_ARG(bool, false));
 		}
 	}
 


### PR DESCRIPTION
OBS would freeze if obs_frontend_set_current_scene was called from a script. This fixes it by allowing Qt to select the best connection type in invokeMethod.